### PR TITLE
fix: next.config, model ARN, and DynamoDB table init

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: "standalone",
+};
+
+export default nextConfig;

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { streamBedrockKBResponse } from "@/lib/bedrock";
-import { getSession, saveSession } from "@/lib/session";
+import { getSession, saveSession, ensureTable } from "@/lib/session";
 import { v4 as uuidv4 } from "uuid";
 
 export const runtime = "nodejs";
@@ -28,6 +28,7 @@ export async function POST(req: NextRequest) {
     });
   }
 
+  await ensureTable();
   const sessionId = incomingSessionId ?? uuidv4();
   const session = (await getSession(sessionId)) ?? {
     sessionId,

--- a/src/lib/bedrock.ts
+++ b/src/lib/bedrock.ts
@@ -44,7 +44,7 @@ export async function* streamBedrockKBResponse(
       type: "KNOWLEDGE_BASE",
       knowledgeBaseConfiguration: {
         knowledgeBaseId: kbId,
-        modelArn: `arn:aws:bedrock:${process.env.AWS_REGION ?? "us-east-1"}::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0`,
+        modelArn: "global.anthropic.claude-sonnet-4-6",
       },
     },
     ...(sessionId ? { sessionId } : {}),


### PR DESCRIPTION
## Changes

- **`next.config.ts` → `next.config.mjs`**: Next.js does not support TypeScript config files, this was causing startup failure
- **Model**: Updated from retired `claude-3-5-sonnet-20241022-v2:0` to `global.anthropic.claude-sonnet-4-6` inference profile
- **DynamoDB**: Added `ensureTable()` call before `getSession()` so the table is auto-created on first run

## Tested

Full SSE streaming, citation display, and session persistence verified against KB `JDB08JN6GV` in `us-east-1`.