### PR TITLE
[可莉] feat: login page with API key auth (#2)

### DIFF
--- a/src/app/api/auth/validate/route.ts
+++ b/src/app/api/auth/validate/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+
+/**
+ * Lightweight API-key validation endpoint.
+ * Does NOT invoke Bedrock — just checks the key against the env var.
+ */
+export async function POST(req: NextRequest) {
+  const apiKey = req.headers.get("x-api-key");
+
+  if (process.env.API_KEY && apiKey !== process.env.API_KEY) {
+    return new Response(JSON.stringify({ valid: false, error: "Invalid API key" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify({ valid: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import AuthGuard from "@/components/AuthGuard";
 
 export const metadata: Metadata = {
   title: "Bedrock KB Chat",
@@ -13,7 +14,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <AuthGuard>{children}</AuthGuard>
+      </body>
     </html>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { validateApiKey, setStoredApiKey } from "@/lib/auth";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [apiKey, setApiKey] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const key = apiKey.trim();
+    if (!key) {
+      setError("Please enter an API key.");
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+
+    const valid = await validateApiKey(key);
+
+    if (valid) {
+      setStoredApiKey(key);
+      router.replace("/");
+    } else {
+      setError("Invalid API key. Please try again.");
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-sm bg-white rounded-2xl shadow-md p-8">
+        {/* Logo / title */}
+        <div className="text-center mb-6">
+          <p className="text-4xl mb-2">💬</p>
+          <h1 className="text-xl font-semibold text-gray-800">Knowledge Base Chat</h1>
+          <p className="text-sm text-gray-500 mt-1">Powered by Amazon Bedrock</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="api-key"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              API Key
+            </label>
+            <input
+              id="api-key"
+              type="password"
+              autoComplete="current-password"
+              placeholder="Enter your API key"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              disabled={loading}
+              className="w-full rounded-xl border border-gray-300 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading || !apiKey.trim()}
+            className="w-full py-2.5 bg-blue-600 text-white rounded-xl text-sm font-medium hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {loading ? "Verifying…" : "Sign in"}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
 import ChatWindow from "@/components/ChatWindow";
+import { clearStoredApiKey } from "@/lib/auth";
 
 export default function Home() {
+  const router = useRouter();
+
+  const handleLogout = () => {
+    clearStoredApiKey();
+    router.replace("/login");
+  };
+
   return (
     <main className="flex flex-col h-screen max-w-4xl mx-auto px-4">
-      <header className="py-4 border-b border-gray-200">
-        <h1 className="text-xl font-semibold text-gray-800">
-          💬 Knowledge Base Chat
-        </h1>
-        <p className="text-sm text-gray-500 mt-0.5">
-          Powered by Amazon Bedrock
-        </p>
+      <header className="py-4 border-b border-gray-200 flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-gray-800">
+            💬 Knowledge Base Chat
+          </h1>
+          <p className="text-sm text-gray-500 mt-0.5">
+            Powered by Amazon Bedrock
+          </p>
+        </div>
+        <button
+          onClick={handleLogout}
+          className="text-xs text-gray-400 hover:text-gray-600 transition-colors px-3 py-1.5 rounded-lg hover:bg-gray-100"
+        >
+          Sign out
+        </button>
       </header>
       <ChatWindow />
     </main>

--- a/src/components/AuthGuard.tsx
+++ b/src/components/AuthGuard.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { getStoredApiKey } from "@/lib/auth";
+
+interface AuthGuardProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Client-side route guard.
+ * Redirects unauthenticated users to /login.
+ * Shows nothing while checking (avoids flash of protected content).
+ */
+export default function AuthGuard({ children }: AuthGuardProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const key = getStoredApiKey();
+    if (!key && pathname !== "/login") {
+      router.replace("/login");
+    } else {
+      setReady(true);
+    }
+  }, [pathname, router]);
+
+  if (!ready) {
+    // Blank screen while checking — avoids flash of protected content
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import MessageBubble, { Message } from "./MessageBubble";
+import { getStoredApiKey } from "@/lib/auth";
 import { v4 as uuidv4 } from "uuid";
 
 export default function ChatWindow() {
@@ -53,7 +54,7 @@ export default function ChatWindow() {
 
     try {
       const headers: Record<string, string> = { "Content-Type": "application/json" };
-      const apiKey = process.env.NEXT_PUBLIC_API_KEY;
+      const apiKey = getStoredApiKey() ?? process.env.NEXT_PUBLIC_API_KEY;
       if (apiKey) headers["x-api-key"] = apiKey;
 
       const res = await fetch("/api/chat", {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,30 @@
+export const AUTH_KEY = "kb_api_key";
+
+/** Returns the stored API key, or null if not authenticated (client-side only). */
+export function getStoredApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(AUTH_KEY);
+}
+
+/** Persists the API key to localStorage. */
+export function setStoredApiKey(key: string): void {
+  localStorage.setItem(AUTH_KEY, key);
+}
+
+/** Clears the stored API key (logout). */
+export function clearStoredApiKey(): void {
+  localStorage.removeItem(AUTH_KEY);
+}
+
+/** Validates an API key against the server. Returns true if valid. */
+export async function validateApiKey(key: string): Promise<boolean> {
+  try {
+    const res = await fetch("/api/auth/validate", {
+      method: "POST",
+      headers: { "x-api-key": key },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## 变更说明

实现 Issue #2 — 在浏览器端输入 API Key，验证通过后才进入聊天界面。

### 新增文件

| 文件 | 说明 |
|------|------|
| `src/app/api/auth/validate/route.ts` | 轻量验证端点，不调用 Bedrock，只检查 API Key 是否匹配 |
| `src/lib/auth.ts` | Auth 工具函数（get/set/clear/validate） |
| `src/app/login/page.tsx` | Login 表单，输入 Key → 验证 → 跳转 |
| `src/components/AuthGuard.tsx` | 客户端路由守卫，未认证自动跳 `/login` |

### 修改文件

| 文件 | 说明 |
|------|------|
| `src/app/layout.tsx` | 用 `AuthGuard` 包裹整个应用 |
| `src/app/page.tsx` | 改为 Client Component，加 Sign out 按钮 |
| `src/components/ChatWindow.tsx` | 从 localStorage 读取 API Key，发请求时作为 `x-api-key` header |

### 用户体验流程

```
未认证 → 访问任意页面 → 自动跳转 /login
输入 API Key → 点 Sign in → /api/auth/validate 验证
验证通过 → 存 localStorage → 跳转 /
验证失败 → 显示错误提示
Sign out 按钮 → 清除 localStorage → 跳回 /login
```

### 设计决策

- **单独验证端点**：`/api/auth/validate` 不调用 Bedrock，只验证 Key，不消耗额度
- **localStorage 存储**：符合 Issue 描述，保持实现简单；后续可替换为 Cognito（#3）
- **AuthGuard 客户端守卫**：Next.js App Router 中 middleware 需要 cookies 才能读取 localStorage，这里用客户端组件实现更简单直接

Closes #2