### PR TITLE
feat: backend userId isolation - GSI + API routes

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { streamBedrockKBResponse } from "@/lib/bedrock";
-import { getSession, saveSession, ensureTable, Session } from "@/lib/session";
+import { getSession, saveSession, ensureTable, ensureGSI, Session } from "@/lib/session";
 import { v4 as uuidv4 } from "uuid";
 
 export const runtime = "nodejs";
@@ -20,7 +20,7 @@ export async function POST(req: NextRequest) {
     return unauthorized();
   }
 
-  const { query, sessionId: incomingSessionId, kbId } = await req.json();
+  const { query, sessionId: incomingSessionId, kbId, userId } = await req.json();
   if (!query?.trim()) {
     return new Response(JSON.stringify({ error: "query is required" }), {
       status: 400,
@@ -29,13 +29,19 @@ export async function POST(req: NextRequest) {
   }
 
   await ensureTable();
+  await ensureGSI().catch(console.warn);
+
   const sessionId = incomingSessionId ?? uuidv4();
   const session: Session = (await getSession(sessionId)) ?? {
     sessionId,
+    userId: userId ?? undefined,
     messages: [],
     createdAt: Date.now(),
     ttl: 0,
   };
+
+  // Backfill userId if not already set (e.g. session pre-existed before this feature)
+  if (userId && !session.userId) session.userId = userId;
 
   // Add user message
   session.messages.push({ role: "user", content: query, ts: Date.now() });

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -4,11 +4,22 @@ import { v4 as uuidv4 } from "uuid";
 
 export async function GET(req: NextRequest) {
   const sessionId = req.nextUrl.searchParams.get("sessionId");
+  const userId = req.nextUrl.searchParams.get("userId") ?? undefined;
+
   if (!sessionId) {
     // Create new session
     const newId = uuidv4();
-    return Response.json({ sessionId: newId, messages: [] });
+    // Pre-create with userId so history queries work from the start
+    await saveSession({
+      sessionId: newId,
+      userId,
+      messages: [],
+      createdAt: Date.now(),
+      ttl: Math.floor(Date.now() / 1000) + 60 * 60 * 2,
+    }).catch(console.error);
+    return Response.json({ sessionId: newId, messages: [], userId });
   }
+
   const session = await getSession(sessionId);
   return Response.json(session ?? { sessionId, messages: [] });
 }

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { DynamoDBDocumentClient, ScanCommand } from "@aws-sdk/lib-dynamodb";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { getSessionsByUser } from "@/lib/session";
 
 const ddbClient = new DynamoDBClient({
   region: process.env.AWS_REGION ?? "us-east-1",
@@ -16,8 +17,8 @@ export interface SessionSummary {
 
 /**
  * GET /api/sessions
- * Returns the 20 most recent sessions (by createdAt desc), each with a preview
- * of the first user message. No user isolation for now.
+ * - With ?userId=xxx: returns sessions for that user (via GSI, with Scan fallback)
+ * - Without userId: returns 20 most recent sessions (full Scan, admin/backward-compat)
  */
 export async function GET(req: NextRequest) {
   // API key auth (same pattern as /api/chat)
@@ -26,7 +27,23 @@ export async function GET(req: NextRequest) {
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const userId = req.nextUrl.searchParams.get("userId");
+
   try {
+    if (userId) {
+      const sessions = await getSessionsByUser(userId);
+      const summaries: SessionSummary[] = sessions
+        .filter((s) => Array.isArray(s.messages) && s.messages.length > 0)
+        .map((s) => ({
+          sessionId: s.sessionId,
+          createdAt: s.createdAt,
+          preview:
+            s.messages.find((m) => m.role === "user")?.content.slice(0, 60) ?? "",
+        }));
+      return Response.json({ sessions: summaries });
+    }
+
+    // No userId: full scan (admin / backward-compat)
     const result = await docClient.send(
       new ScanCommand({
         TableName: TABLE,

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,10 +1,18 @@
 import {
   DynamoDBClient,
   CreateTableCommand,
+  UpdateTableCommand,
+  DescribeTableCommand,
   UpdateTimeToLiveCommand,
   ResourceInUseException,
 } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  ScanCommand,
+} from "@aws-sdk/lib-dynamodb";
 
 const ddbClient = new DynamoDBClient({
   region: process.env.AWS_REGION ?? "us-east-1",
@@ -16,6 +24,7 @@ const TTL_SECONDS = 60 * 60 * 2; // 2 hours
 
 export interface Session {
   sessionId: string;
+  userId?: string;
   bedrockSessionId?: string;
   messages: Array<{ role: "user" | "assistant"; content: string; ts: number }>;
   createdAt: number;
@@ -65,5 +74,91 @@ export async function ensureTable(): Promise<void> {
     );
   } catch (e) {
     if (!(e instanceof ResourceInUseException)) throw e;
+  }
+}
+
+/**
+ * Ensure the userId-createdAt-index GSI exists on the table.
+ * Non-blocking: if GSI is still CREATING, logs a warning and returns.
+ */
+export async function ensureGSI(): Promise<void> {
+  try {
+    const desc = await ddbClient.send(new DescribeTableCommand({ TableName: TABLE }));
+    const existing = desc.Table?.GlobalSecondaryIndexes ?? [];
+    const hasGSI = existing.some((g) => g.IndexName === "userId-createdAt-index");
+    if (!hasGSI) {
+      await ddbClient.send(
+        new UpdateTableCommand({
+          TableName: TABLE,
+          AttributeDefinitions: [
+            { AttributeName: "userId", AttributeType: "S" },
+            { AttributeName: "createdAt", AttributeType: "N" },
+          ],
+          GlobalSecondaryIndexUpdates: [
+            {
+              Create: {
+                IndexName: "userId-createdAt-index",
+                KeySchema: [
+                  { AttributeName: "userId", KeyType: "HASH" },
+                  { AttributeName: "createdAt", KeyType: "RANGE" },
+                ],
+                Projection: { ProjectionType: "ALL" },
+              },
+            },
+          ],
+        })
+      );
+      console.warn(
+        "[session] GSI userId-createdAt-index is being created (async, takes ~minutes). Scan fallback active."
+      );
+    }
+  } catch (e) {
+    console.warn("[session] ensureGSI failed (non-fatal):", e);
+  }
+}
+
+/**
+ * Query sessions by userId using the GSI.
+ * Falls back to a filtered Scan if the GSI is not yet ACTIVE.
+ */
+export async function getSessionsByUser(
+  userId: string,
+  limit = 20
+): Promise<Session[]> {
+  try {
+    const result = await docClient.send(
+      new QueryCommand({
+        TableName: TABLE,
+        IndexName: "userId-createdAt-index",
+        KeyConditionExpression: "userId = :uid",
+        ExpressionAttributeValues: { ":uid": userId },
+        ScanIndexForward: false,
+        Limit: limit,
+      })
+    );
+    return (result.Items ?? []) as Session[];
+  } catch (e: unknown) {
+    const errMsg = e instanceof Error ? e.message : String(e);
+    // GSI may still be creating — fall back to Scan with filter
+    if (
+      errMsg.includes("index") ||
+      errMsg.includes("GSI") ||
+      errMsg.includes("CREATING") ||
+      errMsg.includes("ResourceNotFoundException")
+    ) {
+      console.warn("[session] GSI not ready, falling back to Scan for userId:", userId);
+      const fallback = await docClient.send(
+        new ScanCommand({
+          TableName: TABLE,
+          FilterExpression: "userId = :uid",
+          ExpressionAttributeValues: { ":uid": userId },
+          Limit: 200,
+        })
+      );
+      return (fallback.Items ?? [])
+        .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))
+        .slice(0, limit) as Session[];
+    }
+    throw e;
   }
 }


### PR DESCRIPTION
## 功能：后端 userId 会话隔离

配合前端 commit 79aae36（可莉的工作）完成完整功能。

### 改动概览

**`src/lib/session.ts`**
- `Session` interface 加 `userId?: string`
- `ensureGSI()` — 自动创建 `userId-createdAt-index` GSI（非阻塞，启动时调用）
- `getSessionsByUser(userId, limit)` — 走 GSI Query；GSI 未就绪时自动 Scan 回退

**`src/app/api/chat/route.ts`**
- 接收 `userId` 字段，存入 session
- 为已有 session 回填 `userId`（向后兼容）

**`src/app/api/sessions/route.ts`**
- 支持 `?userId=xxx` query param
- 有 userId → GSI Query（高效）；无 userId → Scan（管理员/向后兼容）

**`src/app/api/session/route.ts`**
- 新建 session 时支持 `?userId=xxx`，预存入 DynamoDB

### 使用方式

```
https://your-app.com/en?kb=<knowledgebase-id>&user=<user-id>
```

### TypeScript
✅ `npx tsc --noEmit` 通过，无类型错误